### PR TITLE
added youtube mobile compatibility

### DIFF
--- a/yt2spotify/services/youtube_ytm.py
+++ b/yt2spotify/services/youtube_ytm.py
@@ -25,6 +25,9 @@ class YoutubeYTMService(MusicService):
 
     @classmethod
     def detect(cls, url: str) -> bool:
+        # convert mobile youtube links to standard Youtube links
+        url = url.replace("m.youtube.com", "youtube.com")
+
         if (
                 not cls.ytpattern.match(url)
                 and not cls.ytchannel_pattern.match(url)
@@ -37,6 +40,9 @@ class YoutubeYTMService(MusicService):
     def url_to_search_params(self, url: str) -> SearchParams:
         # url = url.replace("youtube.com", "music.youtube.com").replace("www.", "")
         # return self.ytm_service.url_to_search_params(url)
+        
+        # convert mobile youtube links to standard Youtube links
+        url = url.replace("m.youtube.com", "youtube.com")
         return self.yt_service.url_to_search_params(url)
 
     def search_with_params(self, params: SearchParams) -> SearchResult:

--- a/yt2spotify/tests/test_youtube_ytm.py
+++ b/yt2spotify/tests/test_youtube_ytm.py
@@ -16,7 +16,10 @@ from yt2spotify.services.service_names import ServiceNameEnum
         ("https://www.youtube.com/watch?v=hT_nvWreIhg", "song"),    # normal video title but channel name has VEVO
         ("https://www.youtube.com/playlist?list=OLAK5uy_mbiRc-WQKXNRCfAeZBsoA-hILP3Oeu2WU", "album"),    # Coldplay - Everyday Life album (official), but channel name according to API is YouTube instead of Coldplay
         ("https://www.youtube.com/playlist?list=PLFAcddgaFN8zqIJrTakvM9qWnR7iIrXnj", "album"),   # Michael Jackson - Thriller album by MusicVevo channel
-        ("https://youtu.be/5waF8YR3GmQ", "song")    # short link
+        ("https://youtu.be/5waF8YR3GmQ", "song"),    # short link
+        ("https://m.youtube.com/watch?v=dQw4w9WgXcQ", "song"),    # Basic mobile video
+        ("https://m.youtube.com/@coldplay", "artist"),            # Mobile artist page
+        ("https://m.youtube.com/playlist?list=PLFAcddgaFN8zqIJrTakvM9qWnR7iIrXnj", "album")  # Mobile playlist
     ]
 )
 def test_url_parsing(test_url, expected_search_hint):
@@ -37,3 +40,14 @@ def test_search_with_params(search_params):
     yt = MusicServiceFactory.create(ServiceNameEnum.YOUTUBE_YTM)
     results = yt.search_with_params(search_params)
     assert len(results.results) > 0
+
+@pytest.mark.parametrize("mobile_url,regular_url", [
+    ("https://m.youtube.com/watch?v=dQw4w9WgXcQ", "https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+    ("https://m.youtube.com/@coldplay", "https://www.youtube.com/@coldplay"),
+    ("https://m.youtube.com/playlist?list=PLFAcddgaFN8zqIJrTakvM9qWnR7iIrXnj", "https://www.youtube.com/playlist?list=PLFAcddgaFN8zqIJrTakvM9qWnR7iIrXnj")
+])
+def test_mobile_url_equivalence(mobile_url, regular_url):
+    yt = MusicServiceFactory.create(ServiceNameEnum.YOUTUBE_YTM)
+    mobile_params = yt.url_to_search_params(mobile_url)
+    regular_params = yt.url_to_search_params(regular_url)
+    assert mobile_params == regular_params


### PR DESCRIPTION
Fixes issue #19: add support for mobile youtube links

This PR enables the converter to handle mobile YouTube URLs (m.youtube.com) by converting them to standard YouTube URLs before processing.

This PR preserves existing URL parsing infrastructure, requires minimal code changes, and includes test coverage for mobile URL variants. (Although there might be edge cases I'm not thinking of?)

Changes:
- Updated URL detection and queries in youtube_ytm.py by replacing "m.youtube.com" with "youtube.com"
- Added mobile URL test cases

All tests in test_youtube_ytm pass. (I didn't check test_converter.py because I don't have API keys for for spotipy, but the eventual search queries remain the same, so it shouldn't make a difference?).